### PR TITLE
strip classes out when cloning the image in createIndicator

### DIFF
--- a/js/blueimp-gallery.js
+++ b/js/blueimp-gallery.js
@@ -1110,6 +1110,7 @@
                 thumbnail = obj.getElementsByTagName && this.helper.query(obj, 'img');
                 if (thumbnail) {
                     thumbnail = thumbnail.cloneNode(false);
+                    thumbnail.setAttribute('class', '');
                 } else if (thumbnailProperty) {
                     thumbnailUrl = this.getItemProperty(obj, thumbnailProperty);
                     if (thumbnailUrl) {


### PR DESCRIPTION
When cloning the image to create a thumbnail, strip out the class so that any styles will be removed from image.

Otherwise, any padding/margins/borders on the image will mess with the thumbnails.

Chers
