### PR TITLE
Added Demo2.js For User Sets

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@ It features swipe, mouse and keyboard navigation, transition effects, slideshow 
 <p><a href="https://github.com/blueimp/Gallery">blueimp Gallery</a> is based on <a href="http://swipejs.com/">Swipe</a>.</p>
 <br>
 <h2>Carousel image gallery</h2>
+<div class="Desc"></div>
 <!-- The Gallery as inline carousel, can be positioned anywhere on the page -->
 <div id="blueimp-image-carousel" class="blueimp-gallery blueimp-gallery-carousel">
     <div class="slides"></div>
@@ -90,6 +91,6 @@ if (!window.jQuery) {
 }
 </script>
 <script src="js/jquery.blueimp-gallery.js"></script>
-<script src="js/demo.js"></script>
+<script src="js/demo2.js"></script>
 </body> 
 </html>

--- a/js/demo.js
+++ b/js/demo.js
@@ -31,6 +31,7 @@ $(function () {
         var carouselLinks = [],
             linksContainer = $('#links'),
             baseUrl;
+            $('div.Desc').append(result.description);
         // Add the demo images as links with thumbnails to the page:
         $.each(result.photos.photo, function (index, photo) {
             baseUrl = 'http://farm' + photo.farm + '.static.flickr.com/' +

--- a/js/demo2.js
+++ b/js/demo2.js
@@ -1,0 +1,68 @@
+$(function () {
+    'use strict';
+	$.getJSON("http://api.flickr.com/services/feeds/photoset.gne?set=72157629060741515&nsid=35213698@N08&lang=en-us&format=json&jsoncallback=?", function(data){  
+	        var listItems = '';
+	        var carouselLinks = [],
+	            linksContainer = $('#links'),
+	            baseUrl;
+	        $('div.Desc').append(data.description);
+	        $.each(data.items, function(i,item){
+//	           <a href="images/banana.jpg" title="Banana">
+//	              <img src="images/thumbnails/banana.jpg" alt="Banana">
+//	           </a>
+				var value = item.media.m;
+				var valueBig = value.replace("m.jpg", "b.jpg");
+				var valueSmall = value.replace("m.jpg", "s.jpg");
+	           listItems
+	               += '<a href="'+valueBig+'" data-gallery>'+
+	                    '<img src="'+valueSmall+'" />'+
+	                  '</a>';
+	                  
+	                  
+	                  carouselLinks.push({
+	                      href: valueBig,
+	                      title: 'Random Images'
+	                      });
+	                  
+	                  
+	        });
+	        $('div.links').append(listItems);
+	        //initialize main slideshow viewer with flickr images.
+	        blueimp.Gallery(carouselLinks, {
+	            container: '#blueimp-image-carousel',
+	            carousel: true
+	        });
+	    });  
+    
+    // Initialize the Gallery as video carousel:
+    blueimp.Gallery([
+        {
+            title: 'Sintel',
+            href: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+            type: 'video/mp4',
+            poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+        },
+        {
+            title: 'Big Buck Bunny',
+            href: 'http://upload.wikimedia.org/wikipedia/commons/7/75/' +
+                'Big_Buck_Bunny_Trailer_400p.ogg',
+            type: 'video/ogg',
+            poster: 'http://upload.wikimedia.org/wikipedia/commons/thumb/7/70/' +
+                'Big.Buck.Bunny.-.Opening.Screen.png/' +
+                '800px-Big.Buck.Bunny.-.Opening.Screen.png'
+        },
+        {
+            title: 'Elephants Dream',
+            href: 'http://upload.wikimedia.org/wikipedia/commons/transcoded/8/83/' +
+                'Elephants_Dream_%28high_quality%29.ogv/' +
+                'Elephants_Dream_%28high_quality%29.ogv.360p.webm',
+            type: 'video/webm',
+            poster: 'http://upload.wikimedia.org/wikipedia/commons/thumb/9/90/' +
+                'Elephants_Dream_s1_proog.jpg/800px-Elephants_Dream_s1_proog.jpg'
+        }
+    ], {
+        container: '#blueimp-video-carousel',
+        carousel: true
+    });
+
+});


### PR DESCRIPTION
I've added a demo2.js to potentially show people that they can pull
down personal sets using the flickr api as well. Incase anyone is
interested in making a personal gallery using a flickr backend.
Possibly useful for portfolios.

I've also added a div in the index.html for the gallery description. 

Not sure if you're interested but I was thinking of making a bunch of modules for your gallery to import images from multiple services. Such as Flickr. 

Regards, 
Eric Robinson
eric.z.robinson@gmail.com
