### PR TITLE
Add delay to 'pause' method as workaround for seek bug

### DIFF
--- a/js/blueimp-gallery-youtube.js
+++ b/js/blueimp-gallery-youtube.js
@@ -105,9 +105,15 @@
         },
 
         onPause: function () {
-            this.listeners.pause();
-            delete this.playStatus;
+			this.setTimeout(this.checkSeek, null, 2000);
         },
+		
+		checkSeek: function() {
+			if(this.stateChange === YT.PlayerState.PAUSED) { // check if current state change is actually paused
+				this.listeners.pause();
+				delete this.playStatus;
+			}
+		},
 
         onStateChange: function (event) {
             switch (event.data) {
@@ -120,6 +126,9 @@
                 this.onPause();
                 break;
             }
+			
+			// Save most recent state change to this.stateChange
+			this.stateChange = event.data;
         },
 
         onError: function (event) {
@@ -175,7 +184,15 @@
                 this.listeners.pause();
                 delete this.playStatus;
             }
-        }
+        },
+		
+        setTimeout: function (func, args, wait) {
+            var that = this;
+            return func && window.setTimeout(function () {
+                func.apply(that, args || []);
+            }, wait || 0);
+        },
+		
 
     });
 


### PR DESCRIPTION
After some research it appears that seeking on a YouTube video triggers a pause event.

http://stackoverflow.com/questions/18138031/how-to-distinguish-seek-from-pause-via-youtube-player-iframe-api

https://groups.google.com/forum/#!topic/youtube-api-gdata/1xGLZ54YOPI

I can't find a permanent fix, but adding a delay (2 seconds seems to work OK) to the execution of the pause function adds an efficient buffer for trigger a false pause.
