### PR TITLE
use getAttribute for non-enumerated properties

### DIFF
--- a/js/blueimp-gallery-youtube.js
+++ b/js/blueimp-gallery-youtube.js
@@ -201,12 +201,12 @@
 
         textFactory: function (obj, callback) {
             var options = this.options,
-                videoId = this.getItemProperty(obj, options.youTubeVideoIdProperty);
+                videoId = obj.getAttribute(options.youTubeVideoIdProperty);
             if (videoId) {
-                if (this.getItemProperty(obj, options.urlProperty) === undefined) {
+                if (obj.getAttribute(options.urlProperty) === null) {
                     obj[options.urlProperty] = '//www.youtube.com/watch?v=' + videoId;
                 }
-                if (this.getItemProperty(obj, options.videoPosterProperty) === undefined) {
+                if (obj.getAttribute(options.videoPosterProperty) === null) {
                     obj[options.videoPosterProperty] = '//img.youtube.com/vi/' + videoId +
                         '/maxresdefault.jpg';
                 }


### PR DESCRIPTION
Allows for embedding YouTube videos like such:

```
<a data-gallery="filtered" type="text/html" youtube="abc123abc123" title="Cool Video"></a>
```

Previously, the 'youtube' property was always failing when accessed via
getItemProperty since it is not an enumerated property.
