### PR TITLE
Adding support for Zepto and ender as helpers

### DIFF
--- a/js/blueimp-gallery.js
+++ b/js/blueimp-gallery.js
@@ -23,7 +23,7 @@
         // Browser globals:
         window.blueimp = window.blueimp || {};
         window.blueimp.Gallery = factory(
-            window.blueimp.helper || window.jQuery
+            window.blueimp.helper || window.Zepto || window.ender || window.jQuery
         );
     }
 }(function ($) {


### PR DESCRIPTION
First of all, thanks for the amazing work!

This change is a small perk for those already using a jQuery-compatible API (such as Zepto or [Ender](http://enderjs.com/) ). This way those users don't have to redefine the helper to point to API.

Conflicts will be hard to come by apart from maybe jQuery and Zepto in the same page, in which case, the latter takes precedence.
