### PR TITLE
Use protocol-relative URL to load image on flickr

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -30,7 +30,7 @@ $(function () {
             baseUrl;
         // Add the demo images as links with thumbnails to the page:
         $.each(result.photos.photo, function (index, photo) {
-            baseUrl = 'http://farm' + photo.farm + '.static.flickr.com/' +
+            baseUrl = '//farm' + photo.farm + '.static.flickr.com/' +
                 photo.server + '/' + photo.id + '_' + photo.secret;
             $('<a/>')
                 .append($('<img>').prop('src', baseUrl + '_s.jpg'))


### PR DESCRIPTION
Flickr supports both http/s protocol, should use protocol-relative URL to load image on flickr, this can also reduce the warning in browser console, because the website use https.
