### PR TITLE
Work around "document not ready"

### DIFF
--- a/js/blueimp-gallery.js
+++ b/js/blueimp-gallery.js
@@ -307,7 +307,7 @@
             if (!speed) {
                 speed = this.options.transitionSpeed;
             }
-            if (this.support.transition) {
+            if (this.support.transition && this.support.transform) {
                 if (!this.options.continuous) {
                     to = this.circle(to);
                 }
@@ -1070,7 +1070,7 @@
         positionSlide: function (index) {
             var slide = this.slides[index];
             slide.style.width = this.slideWidth + 'px';
-            if (this.support.transition) {
+            if (this.support.transition && this.support.transform) {
                 slide.style.left = (index * -this.slideWidth) + 'px';
                 this.move(index, this.index > index ? -this.slideWidth :
                         (this.index < index ? this.slideWidth : 0), 0);
@@ -1106,11 +1106,11 @@
                 this.positionSlide(i);
             }
             // Reposition the slides before and after the given index:
-            if (this.options.continuous && this.support.transition) {
+            if (this.options.continuous && this.support.transition && this.support.transform) {
                 this.move(this.circle(this.index - 1), -this.slideWidth, 0);
                 this.move(this.circle(this.index + 1), this.slideWidth, 0);
             }
-            if (!this.support.transition) {
+            if (!this.support.transition || !this.support.transform) {
                 this.slidesContainer[0].style.left =
                     (this.index * -this.slideWidth) + 'px';
             }


### PR DESCRIPTION
If you start the gallery while the page is still loading (DOMContentLoaded was not yet fired, e.g. on pages with external dependencies like analytics, ads), a javascript-error was thrown for transform was undefined despite transition being defined.

As transition/transform are not absolutely necessary, this patch removes the assumption that "this.support.transform" will be defined if "this.support.transition" is.

Only appended "this.support.transform" to conditions where "this.support.transition" is already checked, so there should be no significant performance penalty, if any.
