### PR TITLE
consume Esc key event

### DIFF
--- a/js/blueimp-gallery.js
+++ b/js/blueimp-gallery.js
@@ -814,6 +814,8 @@
             case 27: // Esc
                 if (this.options.closeOnEscape) {
                     this.close();
+                    // prevent Esc from closing other things
+                    event.stopImmediatePropagation(); 
                 }
                 break;
             case 32: // Space


### PR DESCRIPTION
I had some problems when using Esc key (with jQuery.Hotkeys) as a hotkey in my application *and* for closing the gallery. 
The core of the problem was multiple handlers firing. I solved this by "consuming" the event in the gallery code. I think this is a sane default behavior.