### PR TITLE
Not pause the video when the user is seeking.

### DIFF
--- a/js/blueimp-gallery-video.js
+++ b/js/blueimp-gallery-video.js
@@ -115,6 +115,7 @@
             that.setTimeout(callback, errorArgs)
           })
           .on('pause', function () {
+            if (video.seeking) { return; }
             isLoading = false
             videoContainer
               .removeClass(that.options.videoLoadingClass)


### PR DESCRIPTION
When a user seeks a part of the video, the pause event is fired and then the poster image is shown to the user. This solves the issue.