### PR TITLE
Change 'maxresdefault.jpg' to 'hqdefault.jpg'?

### DIFF
--- a/js/blueimp-gallery-youtube.js
+++ b/js/blueimp-gallery-youtube.js
@@ -207,7 +207,7 @@
         }
         if (this.getItemProperty(obj, options.videoPosterProperty) === undefined) {
           obj[options.videoPosterProperty] = '//img.youtube.com/vi/' + videoId +
-            '/maxresdefault.jpg'
+            '/hqdefault.jpg'
         }
         return this.videoFactory(
           obj,


### PR DESCRIPTION
Not all videos have a **maxresdefault.jpg**. Would it make more sense to default to **hqdefault.jpg**?

Example:
https://img.youtube.com/vi/jNQXAC9IVRw/maxresdefault.jpg
https://img.youtube.com/vi/jNQXAC9IVRw/hqdefault.jpg


Changed

```
if (this.getItemProperty(obj, options.videoPosterProperty) === undefined) {
    obj[options.videoPosterProperty] = '//img.youtube.com/vi/' + videoId +
        '/maxresdefault.jpg'
}
```
to

```
if (this.getItemProperty(obj, options.videoPosterProperty) === undefined) {
    obj[options.videoPosterProperty] = '//img.youtube.com/vi/' + videoId +
        '/hqdefault.jpg'
}
```

