### PR TITLE
Allow data attributes to use any name

### DIFF
--- a/js/blueimp-gallery.js
+++ b/js/blueimp-gallery.js
@@ -1190,29 +1190,32 @@
     },
 
     getDataProperty: function (obj, property) {
-      if (obj.getAttribute) {
-        var prop = obj.getAttribute('data-' +
-          property.replace(/([A-Z])/g, '-$1').toLowerCase())
-        if (typeof prop === 'string') {
-          // eslint-disable-next-line no-useless-escape
-          if (/^(true|false|null|-?\d+(\.\d+)?|\{[\s\S]*\}|\[[\s\S]*\])$/
-              .test(prop)) {
-            try {
-              return $.parseJSON(prop)
-            } catch (ignore) {}
-          }
-          return prop
+      var prop
+      if (obj.dataset) {
+        prop = obj.dataset[property]
+      } else if (obj.getAttribute) {
+        prop = obj.getAttribute('data-' +
+            property.replace(/([A-Z])/g, '-$1').toLowerCase())
+      }
+      if (typeof prop === 'string') {
+        // eslint-disable-next-line no-useless-escape
+        if (/^(true|false|null|-?\d+(\.\d+)?|\{[\s\S]*\}|\[[\s\S]*\])$/
+            .test(prop)) {
+          try {
+            return $.parseJSON(prop)
+          } catch (ignore) {}
         }
+        return prop
       }
     },
 
     getItemProperty: function (obj, property) {
-      var prop = obj[property]
+      var prop = this.getDataProperty(obj, property)
       if (prop === undefined) {
-        prop = this.getDataProperty(obj, property)
-        if (prop === undefined) {
-          prop = this.getNestedProperty(obj, property)
-        }
+        prop = obj[property]
+      }
+      if (prop === undefined) {
+        prop = this.getNestedProperty(obj, property)
       }
       return prop
     },


### PR DESCRIPTION
Some DOM element properties (e.g. the title or id properties) are defined on the HTMLElement prototype as a DOMString which prevents them from ever evaluating as undefined.
This causes any dataset attributes with names overlapping these inherited properties to be ignored by getItemProperty().
When determining the value of an item property we must first check for the existence of an explicitly defined dataset attribute so that any name can be used.