### PR TITLE
Convert hyphenated urlProperty to camelCase for dataset lookup

### DIFF
--- a/js/blueimp-gallery.js
+++ b/js/blueimp-gallery.js
@@ -1192,7 +1192,7 @@
     getDataProperty: function (obj, property) {
       var prop
       if (obj.dataset) {
-        prop = obj.dataset[property]
+        prop = obj.dataset[property.replace(/-([a-z])/g, function(_, b) {return b.toUpperCase()})]
       } else if (obj.getAttribute) {
         prop = obj.getAttribute('data-' +
             property.replace(/([A-Z])/g, '-$1').toLowerCase())


### PR DESCRIPTION
Dataset converts data properties to camelCase. Patch 2.25.1 does not account for hyphenated urlProperty names being used whereas previously they were allowed.