### PR TITLE
Fix issue with RAF callback triggering after the component is unmounted

### DIFF
--- a/js/blueimp-gallery.js
+++ b/js/blueimp-gallery.js
@@ -286,6 +286,12 @@
       window.webkitRequestAnimationFrame ||
       window.mozRequestAnimationFrame,
 
+    cancelAnimationFrame:
+      window.cancelAnimationFrame ||
+      window.webkitCancelRequestAnimationFrame ||
+      window.webkitCancelAnimationFrame ||
+      window.mozCancelAnimationFrame,
+
     initialize: function () {
       this.initStartIndex()
       if (this.initWidget() === false) {
@@ -402,6 +408,12 @@
     pause: function () {
       window.clearTimeout(this.timeout)
       this.interval = null
+
+      if (this.cancelAnimationFrame) {
+        this.cancelAnimationFrame.call(window, this.animationFrameId)
+        this.animationFrameId = null
+      }
+
       this.container.removeClass(this.options.playingClass)
     },
 


### PR DESCRIPTION
We stumbled upon a strange and infrequent browser errors when some users were navigating away from a page containing an animated Gallery.

After a lot of debugging, we pinned it down to a race condition between RAF and the unmount logic. The path to failure is the following:

1. play ST queued
2. play ST solved
3. RAF queued
4. handleClose/close() called
5. this.slides emptied
6. RAF resolved
7. this.slide() called on inconsistent state

Once again, this is very unlikely, but still happens to a few users per month - specially to those on mobile phones.

Hope this PR helps on contributing to an even further cooler module.

Thanks!