### PR TITLE
* enhance thumbnail user experience by showing larger size thumbnail

### DIFF
--- a/css/blueimp-gallery-indicator.css
+++ b/css/blueimp-gallery-indicator.css
@@ -46,16 +46,18 @@
   opacity: 1;
 }
 
+
 .blueimp-gallery > .indicator > li:after {
   opacity: 0;
-  content: '';
   display: block;
   position: absolute;
-  bottom: 30px;
+  content: '';
+  top: -5em;
   width: 75px;
   height: 75px;
   transition: transform 600ms ease-out, opacity 400ms ease-out;
   transform: translateX(-50%) translateY(0) translateZ(0px);
+  pointer-events:none;
 }
 
 .blueimp-gallery > .indicator > li:hover:after {
@@ -63,6 +65,10 @@
   border-radius: 50%;
   background: inherit;
   transform: translateX(-50%) translateY(-5px) translateZ(0px);
+}
+
+.blueimp-gallery > .indicator > .active:after {
+  display: none;
 }
 
 .blueimp-gallery-controls > .indicator {

--- a/css/blueimp-gallery-indicator.css
+++ b/css/blueimp-gallery-indicator.css
@@ -45,6 +45,26 @@
   border-color: #fff;
   opacity: 1;
 }
+
+.blueimp-gallery > .indicator > li:after {
+  opacity: 0;
+  content: '';
+  display: block;
+  position: absolute;
+  bottom: 30px;
+  width: 75px;
+  height: 75px;
+  transition: transform 600ms ease-out, opacity 400ms ease-out;
+  transform: translateX(-50%) translateY(0) translateZ(0px);
+}
+
+.blueimp-gallery > .indicator > li:hover:after {
+  opacity: 1;
+  border-radius: 50%;
+  background: inherit;
+  transform: translateX(-50%) translateY(-5px) translateZ(0px);
+}
+
 .blueimp-gallery-controls > .indicator {
   display: block;
   /* Fix z-index issues (controls behind slide element) on Android: */


### PR DESCRIPTION
Because of small size thumbnail, so that user can't see which image he hovering. So I enhance the user experience by larger thumbnail. 

<img width="312" alt="2017-11-16 16 10 08" src="https://user-images.githubusercontent.com/429250/32880476-71b61848-ca73-11e7-9050-f743b24a072d.png">
