### PR TITLE
Allow multiple galleries to use the same lightbox widget

### DIFF
--- a/js/jquery.blueimp-gallery.js
+++ b/js/jquery.blueimp-gallery.js
@@ -64,7 +64,7 @@
       callbacks
     )
     // Select all links with the same data-gallery attribute:
-    var links = $('[data-gallery="' + id + '"]')
+    var links = $(this).closest('[data-gallery-group], body').find('[data-gallery="' + id + '"]')
     if (options.filter) {
       links = links.filter(options.filter)
     }


### PR DESCRIPTION
Example: 
```html
<div id="fruits" data-gallery-group>
    <a href="images/banana.jpg" title="Banana" data-gallery>
        <img src="images/thumbnails/banana.jpg" alt="Banana">
    </a>
    <a href="images/apple.jpg" title="Apple" data-gallery>
        <img src="images/thumbnails/apple.jpg" alt="Apple">
    </a>
</div>
<div id="vegetables" data-gallery-group>
    <a href="images/tomato.jpg" title="Tomato" data-gallery>
        <img src="images/thumbnails/tomato.jpg" alt="Tomato">
    </a>
    <a href="images/onion.jpg" title="Onion" data-gallery>
        <img src="images/thumbnails/onion.jpg" alt="Onion">
    </a>
</div>
```

Idea is the following:
1. Mark group of images with `data-gallery-group` attr.
2. On click, find the first parent with `data-gallery-group` attr, or fallback to `<body>` (global group).
3. When selecting a links take in account `data-gallery-group`, so only this group will appear in the lightbox.

So, this is pretty soft and non-breaking change. Which will allow multiple galleries to use the same lightbox widget.