### PR TITLE
avoid crash after resetSlides

### DIFF
--- a/js/blueimp-gallery.js
+++ b/js/blueimp-gallery.js
@@ -520,6 +520,8 @@
     },
 
     translate: function(index, x, y, speed) {
+      if (!this.slides[index])
+        return;
       var style = this.slides[index].style
       var transition = this.support.transition
       var transform = this.support.transform


### PR DESCRIPTION
I see some occasional crashes in translate, i believe it's because resetSlides has reset this.slides to []