### PR TITLE
Updated froogaloop2.min.js URL

### DIFF
--- a/js/blueimp-gallery-vimeo.js
+++ b/js/blueimp-gallery-vimeo.js
@@ -62,7 +62,7 @@
 
     loadAPI: function () {
       var that = this
-      var apiUrl = 'https://f.vimeocdn.com/js/froogaloop2.min.js'
+      var apiUrl = 'https://secure-a.vimeocdn.com/js/froogaloop2.min.js'
       var scriptTags = document.getElementsByTagName('script')
       var i = scriptTags.length
       var scriptTag


### PR DESCRIPTION
Looks like the "old" one isn't accessible anymore (maybe in favor of player.js, see https://github.com/vimeo/player.js/blob/master/docs/migrate-from-froogaloop.md)

Fixes #268 